### PR TITLE
bug fix: prettyHist now returns invisibly

### DIFF
--- a/R/Plot4CATA.R
+++ b/R/Plot4CATA.R
@@ -576,7 +576,7 @@ prettyHist <- function(distribution, observed,
     # "Observed value" , pos = 2 , cex = 0.75, col=observed.col)
   }
 
-  return(h)
+  invisible(h)
 }
 #_____________________________________________________________________
 #        1         2         3         4         5         6         7


### PR DESCRIPTION
`prettyHist` returns a list, so user had to capture it in a variable to suppress it from printing. This change lets it return the list invisibly so that capturing it is not required.